### PR TITLE
Feat: Signup dashboard improvements

### DIFF
--- a/apps/buy-sell-cars-south-africa/README.md
+++ b/apps/buy-sell-cars-south-africa/README.md
@@ -26,20 +26,23 @@ A modern vehicle marketplace platform for buying and selling vehicles in South A
 ### Running the app
 
 1. **From the monorepo root:**
+
    ```bash
    # Install all dependencies
    pnpm install
-   
+
    # Start this app specifically
    cd apps/buy-sell-cars-south-africa
    pnpm dev
    ```
 
 2. **Environment setup:**
+
    - Copy `.env.example` to `.env` in this app directory, or
    - Run `vercel env pull` from the app directory
 
 3. **Generate Supabase types:**
+
    ```bash
    pnpm generate-supabase-types
    ```

--- a/apps/buy-sell-cars-south-africa/src/components/Pages/Auth/SignUpForm/components/ProfilePhotoPreviewModal.tsx
+++ b/apps/buy-sell-cars-south-africa/src/components/Pages/Auth/SignUpForm/components/ProfilePhotoPreviewModal.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import { createPortal } from "react-dom";
+import { Button, Typography } from "~bsc-shared/ui";
+import { Box, Flex, VStack } from "@/styled-system/jsx";
+
+type ProfilePhotoPreviewModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  imageSrc: string | null;
+  imageFile: File | null;
+};
+
+export const ProfilePhotoPreviewModal = ({
+  isOpen,
+  onClose,
+  imageSrc,
+  imageFile,
+}: ProfilePhotoPreviewModalProps) => {
+  const [showAnimation, setShowAnimation] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      // Small delay to ensure smooth animation
+      setTimeout(() => setShowAnimation(true), 10);
+    } else {
+      setShowAnimation(false);
+    }
+  }, [isOpen]);
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  if (!isOpen || !isMounted) return null;
+
+  const modalContent = (
+    <Box
+      position="fixed"
+      inset="0"
+      bg="rgba(0, 0, 0, 0.75)"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      zIndex="1000"
+      onClick={handleBackdropClick}
+      style={{
+        transition: "opacity 0.3s",
+        opacity: showAnimation ? 1 : 0,
+      }}
+    >
+      <Box
+        bg="white"
+        marginX="md"
+        padding="lg"
+        borderRadius="1.2rem"
+        shadow="lg"
+        width="100%"
+        maxWidth="40rem"
+        style={{
+          transform: showAnimation ? "scale(1)" : "scale(0.95)",
+          opacity: showAnimation ? 1 : 0,
+          transition: "opacity 0.3s, transform 0.3s",
+        }}
+      >
+        <VStack alignItems="flex-start" gap="md">
+          <Flex justifyContent="space-between" alignItems="center" width="100%">
+            <Typography variant="h4" weight="bold">
+              Profile Photo Preview
+            </Typography>
+            <Button variant="ghost" onClick={onClose}>
+              ✕
+            </Button>
+          </Flex>
+
+          {imageSrc && imageFile ? (
+            <Box width="100%" display="flex" justifyContent="center">
+              <Box
+                position="relative"
+                width="100%"
+                maxWidth="300px"
+                aspectRatio="1"
+                borderRadius="1.2rem"
+                overflow="hidden"
+                border="1px solid"
+                borderColor="grey"
+              >
+                <Image
+                  src={imageSrc}
+                  alt="Profile photo preview"
+                  fill
+                  style={{
+                    objectFit: "cover",
+                  }}
+                  quality={100}
+                />
+              </Box>
+            </Box>
+          ) : (
+            <Box
+              width="100%"
+              height="200px"
+              display="flex"
+              justifyContent="center"
+              alignItems="center"
+              border="2px dashed"
+              borderColor="grey"
+              borderRadius="1.2rem"
+              bg="greyLight"
+            >
+              <Typography color="textLight">No image selected</Typography>
+            </Box>
+          )}
+
+          {imageFile && (
+            <VStack alignItems="flex-start" gap="xs" width="100%">
+              <Typography weight="medium">File Details:</Typography>
+              <Typography>
+                <strong>Name:</strong> {imageFile.name}
+              </Typography>
+              <Typography>
+                <strong>Size:</strong>{" "}
+                {(imageFile.size / 1024 / 1024).toFixed(2)} MB
+              </Typography>
+              <Typography>
+                <strong>Type:</strong> {imageFile.type}
+              </Typography>
+            </VStack>
+          )}
+
+          <Flex
+            gap="md"
+            alignItems="center"
+            width="100%"
+            justifyContent="flex-end"
+          >
+            <Button variant="ghost" onClick={onClose}>
+              Close
+            </Button>
+          </Flex>
+        </VStack>
+      </Box>
+    </Box>
+  );
+
+  return createPortal(modalContent, document.body);
+};

--- a/apps/buy-sell-cars-south-africa/src/components/Pages/Auth/SignUpForm/components/index.ts
+++ b/apps/buy-sell-cars-south-africa/src/components/Pages/Auth/SignUpForm/components/index.ts
@@ -1,0 +1,1 @@
+export { ProfilePhotoPreviewModal } from "./ProfilePhotoPreviewModal";

--- a/apps/buy-sell-cars-south-africa/src/components/Pages/Auth/SignUpForm/index.tsx
+++ b/apps/buy-sell-cars-south-africa/src/components/Pages/Auth/SignUpForm/index.tsx
@@ -8,6 +8,7 @@ import {
   InputField,
   SelectField,
   TextareaField,
+  FileInputField,
 } from "~bsc-shared/components/FormComponents";
 import { USER_CATEGORYS } from "~bsc-shared/constants";
 import { H1, H4, P, Button } from "~bsc-shared/ui";
@@ -18,38 +19,95 @@ import {
   toSnakeCase,
 } from "~bsc-shared/utils";
 import { LOCATIONS } from "@/src/constants/values";
+import { useFileUploadHelpers } from "@/src/hooks";
 import { signUpValidationSchema, signUpFormDefaultValues } from "@/src/schemas";
 import { signUp } from "@/src/server/actions/auth";
 import { type SignUpFormType } from "@/src/types";
-import { Stack, Grid, HStack, Divider } from "@/styled-system/jsx";
+import { Stack, Grid, HStack, Divider, Box } from "@/styled-system/jsx";
+import { createClient } from "@/supabase/client";
+import { ProfilePhotoPreviewModal } from "./components";
 import { Form } from "./index.styled";
 
 export const SignUpForm = () => {
+  const supabase = createClient();
   const [showSuccess, setShowSuccess] = useState(false);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagesPreview, setImagesPreview] = useState<string>("");
+  const [uploading, setUploading] = useState(false);
+  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
 
   const {
     register,
     watch,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isSubmitting },
   } = useForm<SignUpFormType>({
     resolver: zodResolver(signUpValidationSchema),
     mode: "all",
     defaultValues: signUpFormDefaultValues,
   });
 
+  const { compressAndUploadFile } = useFileUploadHelpers(supabase);
+
+  const handlePreviewClick = () => {
+    if (imageFile) {
+      setIsPreviewModalOpen(true);
+    }
+  };
+
+  const handleClosePreview = () => {
+    setIsPreviewModalOpen(false);
+  };
+
   const handleAction = async (formData: SignUpFormType) => {
     try {
-      const { status, error } = await signUp(formData);
+      setUploading(true);
 
-      if (status !== StatusCode.SUCCESS) {
+      if (!imageFile) {
+        return handleClientError("Profile photo is required", null);
+      }
+
+      // Create user first to get user ID
+      const { data: user, status, error } = await signUp(formData);
+
+      if (status !== StatusCode.SUCCESS || !user) {
         return handleClientError("signing up, please try again later.", error);
+      }
+
+      // Upload profile photo
+      const profileLogoPath = await compressAndUploadFile({
+        id: user.id,
+        file: imageFile,
+        bucket: "profile-logos",
+        fileNamePrefix: "profile-logo",
+      });
+
+      if (!profileLogoPath) {
+        return handleClientError(
+          "Profile photo upload failed. Please try again.",
+          null
+        );
+      }
+
+      // Update the user's profile with the logo path
+      const { error: updateError } = await supabase
+        .from("profiles")
+        .update({ profile_logo_path: profileLogoPath })
+        .eq("id", user.id);
+
+      if (updateError) {
+        return handleClientError(
+          "Error updating profile with photo",
+          updateError
+        );
       }
 
       toastNotifySuccess("Sign up Success!");
       setShowSuccess(true);
     } catch (error) {
       handleClientError("signing up", error);
+    } finally {
+      setUploading(false);
     }
   };
 
@@ -67,6 +125,70 @@ export const SignUpForm = () => {
 
       {!showSuccess ? (
         <>
+          {/* Profile Photo Upload Section */}
+          <Box marginBottom="md">
+            <Box marginBottom="sm">
+              <H4>Profile Photo Required</H4>
+            </Box>
+            <Box marginBottom="sm">
+              <P>
+                <i>Upload a profile photo to continue with signup</i>
+              </P>
+            </Box>
+
+            <Grid
+              gridTemplateColumns={{ base: "1fr", sm: "1fr auto" }}
+              gap="sm"
+              alignItems="end"
+            >
+              <FileInputField
+                accept="image/*"
+                label={
+                  uploading || isSubmitting
+                    ? "Uploading..."
+                    : imageFile
+                      ? "Change photo"
+                      : "Choose photo"
+                }
+                name="profileLogoPath"
+                disabled={uploading || isSubmitting}
+                register={{
+                  ...register("profileLogoPath"),
+                  onChange: async (e) => {
+                    const file = e.target.files?.[0];
+                    if (file) {
+                      setImageFile(file);
+                      setImagesPreview(URL.createObjectURL(file));
+                    } else {
+                      setImageFile(null);
+                      setImagesPreview("");
+                    }
+                  },
+                }}
+                errors={errors}
+              />
+
+              {imageFile && (
+                <Button
+                  type="button"
+                  onClick={handlePreviewClick}
+                  disabled={uploading || isSubmitting}
+                >
+                  Preview
+                </Button>
+              )}
+            </Grid>
+
+            {imageFile && (
+              <Box marginTop="sm">
+                <P style={{ opacity: 0.3 }}>
+                  Selected: {imageFile.name} (
+                  {(imageFile.size / 1024 / 1024).toFixed(2)} MB)
+                </P>
+              </Box>
+            )}
+          </Box>
+
           <Grid gridTemplateColumns={{ base: "1fr", sm: "1fr 1fr" }} gap="sm">
             <InputField
               label="First name"
@@ -153,6 +275,13 @@ export const SignUpForm = () => {
               ))}
             </SelectField>
 
+            <InputField
+              label="Address"
+              name="address"
+              register={register}
+              errors={errors}
+            />
+
             <TextareaField
               label="Description"
               name="description"
@@ -179,7 +308,9 @@ export const SignUpForm = () => {
           />
 
           <Stack alignItems="center" marginTop="md">
-            <Button type="submit">Submit</Button>
+            <Button type="submit" disabled={uploading || isSubmitting}>
+              {uploading || isSubmitting ? "Creating Account..." : "Submit"}
+            </Button>
           </Stack>
 
           <Divider marginY="md" color="grey" />
@@ -207,6 +338,13 @@ export const SignUpForm = () => {
           </Link>
         </Stack>
       )}
+
+      <ProfilePhotoPreviewModal
+        isOpen={isPreviewModalOpen}
+        onClose={handleClosePreview}
+        imageSrc={imagesPreview}
+        imageFile={imageFile}
+      />
     </Form>
   );
 };

--- a/apps/buy-sell-cars-south-africa/src/components/Pages/Dashboard/Account.tsx
+++ b/apps/buy-sell-cars-south-africa/src/components/Pages/Dashboard/Account.tsx
@@ -73,10 +73,12 @@ export const Account = ({ profile }: { profile: Profile | null }) => {
           })
         : profileLogoPath;
 
-      try {
-        await deleteOldFiles("profile-logos", [profileLogoPath || ""]);
-      } catch (err) {
-        return handleClientError("deleting old profile logo", err);
+      if (imageFile) {
+        try {
+          await deleteOldFiles("profile-logos", [profileLogoPath || ""]);
+        } catch (err) {
+          return handleClientError("deleting old profile logo", err);
+        }
       }
 
       const newGovernmentIdPath = idFile
@@ -88,10 +90,12 @@ export const Account = ({ profile }: { profile: Profile | null }) => {
           })
         : governmentIdPath;
 
-      try {
-        await deleteOldFiles("government-ids", [governmentIdPath || ""]);
-      } catch (err) {
-        return handleClientError("deleting old government ID", err);
+      if (idFile) {
+        try {
+          await deleteOldFiles("government-ids", [governmentIdPath || ""]);
+        } catch (err) {
+          return handleClientError("deleting old government ID", err);
+        }
       }
 
       const updatedProfile = {
@@ -264,7 +268,7 @@ export const Account = ({ profile }: { profile: Profile | null }) => {
           label="Phone number"
           name="phone"
           type="tel"
-          placeholder="+1 234 567 8900"
+          placeholder="+1 234..."
           register={register}
           errors={errors}
         />

--- a/apps/buy-sell-cars-south-africa/src/schemas/authValidationSchemas.ts
+++ b/apps/buy-sell-cars-south-africa/src/schemas/authValidationSchemas.ts
@@ -33,8 +33,14 @@ export const signUpValidationSchema = z
     location: z.string().min(2, {
       message: "Location is required",
     }),
+    address: z.string().min(2, {
+      message: "Address must be at least 2 characters",
+    }),
     description: z.string().min(10, {
       message: "Description must be at least 10 characters",
+    }),
+    profileLogoPath: z.any().refine((file) => file !== undefined, {
+      message: "Profile photo is required",
     }),
     password: z.string().min(8, {
       message: "Password must be at least 8 characters",

--- a/apps/buy-sell-cars-south-africa/src/schemas/constants.ts
+++ b/apps/buy-sell-cars-south-africa/src/schemas/constants.ts
@@ -21,9 +21,11 @@ export const signUpFormDefaultValues = {
   categoryType: undefined,
   dealershipName: null,
   location: "",
+  address: "",
   password: "",
   confirmPassword: "",
   description: "",
+  profileLogoPath: undefined,
 } satisfies SignUpFormType;
 
 export const updateProfileFormDefaultValues = (profile: Profile) => {

--- a/apps/buy-sell-cars-south-africa/src/server/actions/auth.ts
+++ b/apps/buy-sell-cars-south-africa/src/server/actions/auth.ts
@@ -96,6 +96,7 @@ export const signUp = async (formData: SignUpFormType) => {
       user_category: parsedData.categoryType,
       dealership_name: parsedData.dealershipName || null,
       location: parsedData.location || null,
+      address: parsedData.address || null,
       description: parsedData.description || null,
     };
 

--- a/apps/buy-sell-cars-zimbabwe/src/app/dashboard/add-listing/page.tsx
+++ b/apps/buy-sell-cars-zimbabwe/src/app/dashboard/add-listing/page.tsx
@@ -3,6 +3,8 @@ import { redirect } from "next/navigation";
 import { AddListing } from "@/src/components/Pages/Dashboard";
 import { PendingVerification } from "@/src/components/Pages/Dashboard/components";
 import { fetchUserAndProfile } from "@/src/server/actions/auth";
+import { getProfileSubscriptionDetails } from "@/src/server/actions/general";
+import { shouldAllowDashboardAccess } from "@/src/utils/vehicleVisibilityHelpers";
 
 export const metadata: Metadata = {
   title: "Add Listing",
@@ -14,6 +16,15 @@ const AddListingPage = async () => {
 
   if (!profile) {
     redirect("/sign-in");
+  }
+
+  // Check subscription access control
+  const { data: subscription } = await getProfileSubscriptionDetails(
+    profile.id
+  );
+
+  if (!shouldAllowDashboardAccess(profile, subscription)) {
+    redirect("/dashboard/subscriptions");
   }
 
   const isVerified = Boolean(profile.is_verified);

--- a/apps/buy-sell-cars-zimbabwe/src/app/dashboard/listings/page.tsx
+++ b/apps/buy-sell-cars-zimbabwe/src/app/dashboard/listings/page.tsx
@@ -7,6 +7,7 @@ import {
   getAllVehiclesByOwnerId,
   getProfileSubscriptionDetails,
 } from "@/src/server/actions/general";
+import { shouldAllowDashboardAccess } from "@/src/utils/vehicleVisibilityHelpers";
 
 export const metadata: Metadata = {
   title: "Listings | Your Vehicles",
@@ -27,6 +28,11 @@ const ListingsPage = async () => {
     status: profileSubStatus,
     error: profileSubError,
   } = await getProfileSubscriptionDetails(profile.id);
+
+  // Check subscription access control
+  if (!shouldAllowDashboardAccess(profile, profileSubData)) {
+    redirect("/dashboard/subscriptions");
+  }
 
   const profileSubscription = profileSubData?.subscription_name;
 

--- a/apps/buy-sell-cars-zimbabwe/src/app/dashboard/page.tsx
+++ b/apps/buy-sell-cars-zimbabwe/src/app/dashboard/page.tsx
@@ -3,6 +3,8 @@ import { redirect } from "next/navigation";
 import { Account } from "@/src/components/Pages";
 import { PendingVerification } from "@/src/components/Pages/Dashboard/components";
 import { fetchUserAndProfile } from "@/src/server/actions/auth";
+import { getProfileSubscriptionDetails } from "@/src/server/actions/general";
+import { shouldAllowDashboardAccess } from "@/src/utils/vehicleVisibilityHelpers";
 
 export const metadata: Metadata = {
   title: "Dashboard | Your Account",
@@ -14,6 +16,15 @@ const AccountPage = async () => {
 
   if (!profile) {
     redirect("/sign-in");
+  }
+
+  // Check subscription access control
+  const { data: subscription } = await getProfileSubscriptionDetails(
+    profile.id
+  );
+
+  if (!shouldAllowDashboardAccess(profile, subscription)) {
+    redirect("/dashboard/subscriptions");
   }
 
   const isVerified = Boolean(profile.is_verified);

--- a/apps/buy-sell-cars-zimbabwe/src/app/dashboard/performance/page.tsx
+++ b/apps/buy-sell-cars-zimbabwe/src/app/dashboard/performance/page.tsx
@@ -3,6 +3,8 @@ import { redirect } from "next/navigation";
 import { Performance } from "@/src/components/Pages";
 import { PendingVerification } from "@/src/components/Pages/Dashboard/components";
 import { fetchUserAndProfile } from "@/src/server/actions/auth";
+import { getProfileSubscriptionDetails } from "@/src/server/actions/general";
+import { shouldAllowDashboardAccess } from "@/src/utils/vehicleVisibilityHelpers";
 
 export const metadata: Metadata = {
   title: "Dashboard | Performance",
@@ -14,6 +16,15 @@ const PerformancePage = async () => {
 
   if (!profile) {
     redirect("/sign-in");
+  }
+
+  // Check subscription access control
+  const { data: subscription } = await getProfileSubscriptionDetails(
+    profile.id
+  );
+
+  if (!shouldAllowDashboardAccess(profile, subscription)) {
+    redirect("/dashboard/subscriptions");
   }
 
   const isVerified = Boolean(profile.is_verified);

--- a/apps/buy-sell-cars-zimbabwe/src/app/dashboard/security/page.tsx
+++ b/apps/buy-sell-cars-zimbabwe/src/app/dashboard/security/page.tsx
@@ -2,6 +2,8 @@ import { type Metadata } from "next";
 import { redirect } from "next/navigation";
 import { Security } from "@/src/components/Pages";
 import { fetchUserAndProfile } from "@/src/server/actions/auth";
+import { getProfileSubscriptionDetails } from "@/src/server/actions/general";
+import { shouldAllowDashboardAccess } from "@/src/utils/vehicleVisibilityHelpers";
 
 export const metadata: Metadata = {
   title: "Security | Your Account",
@@ -13,6 +15,15 @@ const SecurityPage = async () => {
 
   if (!profile) {
     redirect("/sign-in");
+  }
+
+  // Check subscription access control
+  const { data: subscription } = await getProfileSubscriptionDetails(
+    profile.id
+  );
+
+  if (!shouldAllowDashboardAccess(profile, subscription)) {
+    redirect("/dashboard/subscriptions");
   }
 
   return <Security />;

--- a/apps/buy-sell-cars-zimbabwe/src/components/Pages/Auth/SignUpForm/components/ProfilePhotoPreviewModal.tsx
+++ b/apps/buy-sell-cars-zimbabwe/src/components/Pages/Auth/SignUpForm/components/ProfilePhotoPreviewModal.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import { createPortal } from "react-dom";
+import { Button, Typography } from "~bsc-shared/ui";
+import { Box, Flex, VStack } from "@/styled-system/jsx";
+
+type ProfilePhotoPreviewModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  imageSrc: string | null;
+  imageFile: File | null;
+};
+
+export const ProfilePhotoPreviewModal = ({
+  isOpen,
+  onClose,
+  imageSrc,
+  imageFile,
+}: ProfilePhotoPreviewModalProps) => {
+  const [showAnimation, setShowAnimation] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      // Small delay to ensure smooth animation
+      setTimeout(() => setShowAnimation(true), 10);
+    } else {
+      setShowAnimation(false);
+    }
+  }, [isOpen]);
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  if (!isOpen || !isMounted) return null;
+
+  const modalContent = (
+    <Box
+      position="fixed"
+      inset="0"
+      bg="rgba(0, 0, 0, 0.75)"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      zIndex="1000"
+      onClick={handleBackdropClick}
+      style={{
+        transition: "opacity 0.3s",
+        opacity: showAnimation ? 1 : 0,
+      }}
+    >
+      <Box
+        bg="white"
+        marginX="md"
+        padding="lg"
+        borderRadius="1.2rem"
+        shadow="lg"
+        width="100%"
+        maxWidth="40rem"
+        style={{
+          transform: showAnimation ? "scale(1)" : "scale(0.95)",
+          opacity: showAnimation ? 1 : 0,
+          transition: "opacity 0.3s, transform 0.3s",
+        }}
+      >
+        <VStack alignItems="flex-start" gap="md">
+          <Flex justifyContent="space-between" alignItems="center" width="100%">
+            <Typography variant="h4" weight="bold">
+              Profile Photo Preview
+            </Typography>
+            <Button variant="ghost" onClick={onClose}>
+              ✕
+            </Button>
+          </Flex>
+
+          {imageSrc && imageFile ? (
+            <Box width="100%" display="flex" justifyContent="center">
+              <Box
+                position="relative"
+                width="100%"
+                maxWidth="300px"
+                aspectRatio="1"
+                borderRadius="1.2rem"
+                overflow="hidden"
+                border="1px solid"
+                borderColor="grey"
+              >
+                <Image
+                  src={imageSrc}
+                  alt="Profile photo preview"
+                  fill
+                  style={{
+                    objectFit: "cover",
+                  }}
+                  quality={100}
+                />
+              </Box>
+            </Box>
+          ) : (
+            <Box
+              width="100%"
+              height="200px"
+              display="flex"
+              justifyContent="center"
+              alignItems="center"
+              border="2px dashed"
+              borderColor="grey"
+              borderRadius="1.2rem"
+              bg="greyLight"
+            >
+              <Typography color="textLight">No image selected</Typography>
+            </Box>
+          )}
+
+          {imageFile && (
+            <VStack alignItems="flex-start" gap="xs" width="100%">
+              <Typography weight="medium">File Details:</Typography>
+              <Typography>
+                <strong>Name:</strong> {imageFile.name}
+              </Typography>
+              <Typography>
+                <strong>Size:</strong>{" "}
+                {(imageFile.size / 1024 / 1024).toFixed(2)} MB
+              </Typography>
+              <Typography>
+                <strong>Type:</strong> {imageFile.type}
+              </Typography>
+            </VStack>
+          )}
+
+          <Flex
+            gap="md"
+            alignItems="center"
+            width="100%"
+            justifyContent="flex-end"
+          >
+            <Button variant="ghost" onClick={onClose}>
+              Close
+            </Button>
+          </Flex>
+        </VStack>
+      </Box>
+    </Box>
+  );
+
+  return createPortal(modalContent, document.body);
+};

--- a/apps/buy-sell-cars-zimbabwe/src/components/Pages/Auth/SignUpForm/components/index.ts
+++ b/apps/buy-sell-cars-zimbabwe/src/components/Pages/Auth/SignUpForm/components/index.ts
@@ -1,0 +1,1 @@
+export { ProfilePhotoPreviewModal } from "./ProfilePhotoPreviewModal";

--- a/apps/buy-sell-cars-zimbabwe/src/components/Pages/Auth/SignUpForm/index.styled.ts
+++ b/apps/buy-sell-cars-zimbabwe/src/components/Pages/Auth/SignUpForm/index.styled.ts
@@ -3,16 +3,19 @@ import { styled } from "@/styled-system/jsx";
 export const Form = styled("form", {
   base: {
     marginX: "auto",
-    marginY: "lg",
+    marginY: { base: "sm", sm: "md" },
     display: "flex",
     flexDirection: "column",
     gap: "sm",
     width: "100%",
-    maxWidth: "55rem",
+    maxWidth: { base: "100%", sm: "45rem", lg: "50rem" },
+    maxHeight: { base: "calc(100vh - 2rem)", sm: "calc(100vh - 4rem)" },
+    overflowY: "auto",
     border: "2px solid transparent",
-    padding: "lg",
+    padding: { base: "md", sm: "lg" },
     borderRadius: "1.2rem",
     backgroundColor: "white",
     boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
+    boxSizing: "border-box",
   },
 });

--- a/apps/buy-sell-cars-zimbabwe/src/components/Pages/Dashboard/Account.tsx
+++ b/apps/buy-sell-cars-zimbabwe/src/components/Pages/Dashboard/Account.tsx
@@ -73,10 +73,12 @@ export const Account = ({ profile }: { profile: Profile | null }) => {
           })
         : profileLogoPath;
 
-      try {
-        await deleteOldFiles("profile-logos", [profileLogoPath || ""]);
-      } catch (err) {
-        return handleClientError("deleting old profile logo", err);
+      if (imageFile) {
+        try {
+          await deleteOldFiles("profile-logos", [profileLogoPath || ""]);
+        } catch (err) {
+          return handleClientError("deleting old profile logo", err);
+        }
       }
 
       const newGovernmentIdPath = idFile
@@ -88,10 +90,12 @@ export const Account = ({ profile }: { profile: Profile | null }) => {
           })
         : governmentIdPath;
 
-      try {
-        await deleteOldFiles("government-ids", [governmentIdPath || ""]);
-      } catch (err) {
-        return handleClientError("deleting old government ID", err);
+      if (idFile) {
+        try {
+          await deleteOldFiles("government-ids", [governmentIdPath || ""]);
+        } catch (err) {
+          return handleClientError("deleting old government ID", err);
+        }
       }
 
       const updatedProfile = {

--- a/apps/buy-sell-cars-zimbabwe/src/components/Pages/Dashboard/Subscriptions/SubscriptionsDashboard.tsx
+++ b/apps/buy-sell-cars-zimbabwe/src/components/Pages/Dashboard/Subscriptions/SubscriptionsDashboard.tsx
@@ -63,6 +63,7 @@ export const SubscriptionsDashboard = ({
   const isCancelled = cancel_time !== null;
   const isIndividual = user_category === "individual";
   const subscriptionPlanName = subscription_name || "No Plan Selected";
+  const showMustSubscribeBanner = subscriptionPlanName === "No Plan Selected";
   const isTrialActive = hasActiveTrialAccess(subscription);
 
   const remainingTrialDays = getRemainingTrialDays(subscription);
@@ -572,6 +573,13 @@ export const SubscriptionsDashboard = ({
               {subscriptionPlan}
             </Span>
           </H4>
+
+          {showMustSubscribeBanner && (
+            <P color="error" weight="bold">
+              (You must subscribe to a plan to access full features. Click
+              button below to get started.)
+            </P>
+          )}
 
           {subscription && !isIndividual && (
             <>

--- a/apps/buy-sell-cars-zimbabwe/src/components/Pages/Dashboard/Subscriptions/components/SubscriptionCard.tsx
+++ b/apps/buy-sell-cars-zimbabwe/src/components/Pages/Dashboard/Subscriptions/components/SubscriptionCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { JSX, useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { useSearchParams, useRouter } from "next/navigation";
 import { Typography, Button } from "~bsc-shared/ui";
 import {
   handleClientError,
@@ -37,6 +37,7 @@ export const SubscriptionCard = ({
 }: SubscriptionCardProps) => {
   const [isLoading, setIsLoading] = useState(false);
 
+  const router = useRouter();
   const searchParams = useSearchParams();
   const isUpgradeFlow = searchParams.get("upgrade") === "true";
 
@@ -78,7 +79,8 @@ export const SubscriptionCard = ({
         toastNotifySuccess(
           "Your 14-day free trial has started! Welcome to BuySellCars!"
         );
-        window.location.reload(); // Refresh to show updated dashboard
+        router.refresh();
+        router.push("/dashboard/subscriptions");
       }
     } catch (error) {
       logErrorMessage(error, "starting trial");

--- a/apps/buy-sell-cars-zimbabwe/src/context/auth-context.tsx
+++ b/apps/buy-sell-cars-zimbabwe/src/context/auth-context.tsx
@@ -51,7 +51,9 @@ export const AuthProvider = ({
         .single();
 
       if (profileError) {
-        console.error("Profile fetch error:", profileError);
+        if (process.env.NODE_ENV === "development") {
+          console.warn("Profile fetch error:", profileError);
+        }
       } else {
         setProfile(profileData);
       }

--- a/apps/buy-sell-cars-zimbabwe/src/schemas/authValidationSchemas.ts
+++ b/apps/buy-sell-cars-zimbabwe/src/schemas/authValidationSchemas.ts
@@ -33,8 +33,14 @@ export const signUpValidationSchema = z
     location: z.string().min(2, {
       message: "Location is required",
     }),
+    address: z.string().min(2, {
+      message: "Address must be at least 2 characters",
+    }),
     description: z.string().min(10, {
       message: "Description must be at least 10 characters",
+    }),
+    profileLogoPath: z.any().refine((file) => file !== undefined, {
+      message: "Profile photo is required",
     }),
     password: z.string().min(8, {
       message: "Password must be at least 8 characters",

--- a/apps/buy-sell-cars-zimbabwe/src/schemas/constants.ts
+++ b/apps/buy-sell-cars-zimbabwe/src/schemas/constants.ts
@@ -21,9 +21,11 @@ export const signUpFormDefaultValues = {
   categoryType: undefined,
   dealershipName: null,
   location: "",
+  address: "",
   password: "",
   confirmPassword: "",
   description: "",
+  profileLogoPath: null,
 } satisfies SignUpFormType;
 
 export const updateProfileFormDefaultValues = (profile: Profile) => {

--- a/apps/buy-sell-cars-zimbabwe/src/server/actions/auth.ts
+++ b/apps/buy-sell-cars-zimbabwe/src/server/actions/auth.ts
@@ -96,8 +96,11 @@ export const signUp = async (formData: SignUpFormType) => {
       user_category: parsedData.categoryType,
       dealership_name: parsedData.dealershipName || null,
       location: parsedData.location || null,
+      address: parsedData.address || null,
       description: parsedData.description || null,
     };
+
+    console.log("[createUserData]", createUserData);
 
     // Sign up with Supabase Auth and pass user data to the profiles table
     const {

--- a/apps/buy-sell-cars-zimbabwe/src/utils/__tests__/vehicleVisibilityHelpers.test.ts
+++ b/apps/buy-sell-cars-zimbabwe/src/utils/__tests__/vehicleVisibilityHelpers.test.ts
@@ -1,36 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { Subscription, VehicleWithImage } from "@/src/types";
+import { Subscription } from "@/src/types";
 import {
   shouldVehicleBeVisible,
   getVehicleStatusMessage,
 } from "../vehicleVisibilityHelpers";
 
 describe("vehicleVisibilityHelpers", () => {
-  const mockVehicle = {
-    id: "test-vehicle-id",
-    owner_id: "test-owner-id",
-    make: "Toyota",
-    model: "Camry",
-    year: 2020,
-    price: 25000,
-    condition: "used",
-    fuel: "petrol",
-    gear_box: "automatic",
-    mileage: 50000,
-    doors: 4,
-    seats: 5,
-    location: "Harare",
-    description: "Test vehicle",
-    is_active: true,
-    is_feature: false,
-    vehicle_category: "car",
-    listing_category: "for_sale",
-    created_at: "2023-01-01T00:00:00.000Z",
-    updated_at: "2023-01-01T00:00:00.000Z",
-    spec_sheet_path: null,
-    images: [],
-  } satisfies VehicleWithImage;
-
   const mockActiveTrialSubscription: Subscription = {
     id: "test-id",
     profile_id: "test-profile-id",
@@ -108,10 +83,6 @@ describe("vehicleVisibilityHelpers", () => {
     });
 
     it("should return false for dealership with cancelled trial", () => {
-      const cancelledTrial = {
-        ...mockActiveTrialSubscription,
-        status: "cancelled" as const,
-      };
       const result = shouldVehicleBeVisible(null, "dealership", null);
       expect(result).toBe(false);
     });

--- a/packages/shared/components/AuthLayout/AuthLayout.tsx
+++ b/packages/shared/components/AuthLayout/AuthLayout.tsx
@@ -21,11 +21,17 @@ export const AuthLayout = ({ children }: { children: React.ReactNode }) => {
         <VStack
           height="100vh"
           overflowY="auto"
-          paddingX="lg"
+          paddingX={{ base: "sm", sm: "md", lg: "lg" }}
+          paddingY="md"
           justifyContent={{ base: "normal", md: "center" }}
           zIndex={1}
+          width="100%"
+          maxWidth="100%"
+          alignItems="center"
         >
-          {children}
+          <Box width="100%" maxWidth="100%">
+            {children}
+          </Box>
         </VStack>
 
         {/* Empty right column on large screens */}


### PR DESCRIPTION
## Why did I do this? 🤔

The signup experience needed enhancement to capture more comprehensive user information upfront, and the dashboard required access control to prevent unauthorised usage based on subscription status. Additionally, error messages throughout the platform were too technical for end users.

## What I did 🧑‍💻

 - Enhanced signup flow with profile photo upload - Added comprehensive profile photo selection, preview modal, and upload functionality to both Zimbabwe and South Africa apps
  - Implemented dashboard subscription-based access control - Added validation checks across all dashboard pages to redirect users without active subscriptions to the subscriptions page
  - Improved error handling with user-friendly messages - Enhanced error translation system to convert technical database/Supabase errors into clear, actionable messages for users
  - Added address field to signup schema - Extended user profile creation to capture address information during registration
  - Fixed profile update file deletion issue - Prevented unnecessary file deletion when updating dashboard profiles
  - Updated vehicle visibility helper tests - Streamlined test cases to focus on core functionality and removed redundant test scenarios
  - Enhanced subscription validation logic - Added shouldAllowDashboardAccess utility function to centralise subscription access control
  - Improved documentation formatting - Enhanced README readability and structure

<details>
<summary><h2>Screenshots 🤩</h2></summary>

<img width="1728" height="1079" alt="Screenshot 2025-09-09 at 17 38 58" src="https://github.com/user-attachments/assets/7fd5b379-bb2d-41b4-8dac-6bc938662977" />

</details>

**Task Ref: [Notion ticket](link)**

<!--

Before merging, ensure the below points have been considered:

- All tests have passed ✅
- Project build status is: Ready ✅
- You've inserted additional images, files or ref links (if relevant).
- And of course, emojis are more than welcome! 😁
-->
